### PR TITLE
[ONEM-26996] Unify hls/fmp4_multiaudio video segment size

### DIFF
--- a/generate_hls.sh
+++ b/generate_hls.sh
@@ -77,7 +77,7 @@ if [ ! -f $hls_path/fmp4_multiaudio/main.m3u8 ]; then
   mkdir -p $hls_path/fmp4_multiaudio
   ffmpeg -i $progressive_path/bbb_h264_aac.mp4 -i $progressive_path/tos_h264_aac.mp4 \
     -map 0:v:0 -map 0:a:0 -map 1:a:0 \
-    -b:v:0 1000k -c:v:1 copy -filter:v:1 "scale=640:-1" \
+    -b:v:0 1000k -c:v:1 copy -filter:v:1 "scale=640:-1" -g 96 -keyint_min 24 \
     -b:a:0 192k -c:a:0 copy -metadata:s:a:0 language=en \
     -b:a:1 192k -c:a:1 copy -metadata:s:a:1 language=pl \
     -f hls -hls_time 4 -hls_playlist_type vod -hls_flags independent_segments \


### PR DESCRIPTION
There is a rare failure of hls-shaka-test.HLS-FMP4-MULTIAUDIO AudioTracks
due to actual playback position being lower than the expected one.

This is likely caused by some buffer underflow, which slows down the
playback. hls/fmp4_multiaudio video stream segments are highly irregular in
size (which varies from 200K to 2M), which may lead to issues like that.

This change sets more constraints on the stream generation to make sure
that video segments are similar in size.