### PR TITLE
Do not commit js_mse_eme patch

### DIFF
--- a/prepare_submodule.sh
+++ b/prepare_submodule.sh
@@ -21,4 +21,4 @@ set -e
 
 git submodule update --init --depth 1
 cd js_mse_eme
-git am ../patches/0001_js_mse_eme_mvt.patch
+git apply ../patches/0001_js_mse_eme_mvt.patch


### PR DESCRIPTION
`git am` command creates a commit and that commit hash can be easily
commited as submodule's active reference. The problem is that our patch
does not exist in remote js_mse_eme repository, so overriding the
submodule's hash may lead to incorrect repository state.

It is much safer to use `git apply` instead, because other git commands
ignore uncommited submodule's changes.