### PR TITLE
Remove getTestResults changes from patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Most of the URL parameters can be combined. Here's a full list of supported quer
 
 ### JavaScript API
 
-`getTestResults()` is a globally available JavaScript function, which can be run from console or via WebDriver to gather the results.
+`getMvtTestResults()` is a globally available JavaScript function, which can be run from console or via WebDriver to gather the results.
 It produces a JSON-like object, which should be easy to read by any automated test runner. Sample output:
 
 ```
@@ -209,6 +209,8 @@ It produces a JSON-like object, which should be easy to read by any automated te
     "ver": "1.0"
 }
 ```
+Please note there is also the original `getTestResults()` function provided by the `js_mse_eme`.
+It is still supported, but it uses different output format and does not include execution logs.
 
 ### Coverage
 
@@ -271,7 +273,7 @@ In example, to execute `DASH shaka` test suite the test runner should:
 
    command evaluates to true.
 
-4. Fetch test results through `WebDriver` with `return getTestResults()`
+4. Fetch test results through `WebDriver` with `return getMvtTestResults()`
 5. Parse JSON test results to adjust it for the format expected by CI system.
 
 Same procedure can be repeated for each test suite in order to make fully automated MVT test run.

--- a/patches/0001_js_mse_eme_mvt.patch
+++ b/patches/0001_js_mse_eme_mvt.patch
@@ -1,7 +1,7 @@
-From 2eb2e57c63fdf02d905425c8639dd507659abe92 Mon Sep 17 00:00:00 2001
+From 3a680d834af901766c20a80c5cc3361536a7b63e Mon Sep 17 00:00:00 2001
 From: Maciej Kolanski <maciej.kolanski@consult.red>
-Date: Fri, 8 Jul 2022 12:07:08 +0200
-Subject: [PATCH] [PATCH] MVT changes
+Date: Mon, 11 Jul 2022 12:54:50 +0200
+Subject: [PATCH] MVT changes
 
 * Load MVT tests instead of the upstream tests
 * Add execution logs to test results
@@ -12,14 +12,14 @@ Subject: [PATCH] [PATCH] MVT changes
 * Remove some unsupported links
 * Add links to YouTube test suite and Media Coverage
 ---
- harness/compactTestView.js | 33 +++++++++---------------
+ harness/compactTestView.js | 33 +++++++++++------------------
  harness/constants.js       |  3 ++-
- harness/main.js            | 13 ++++++++--
- harness/test.js            | 53 ++++++++++----------------------------
- harness/testView.js        | 39 +++++++++++++++++-----------
- harness/timeout.js         |  9 +++++++
- style.css                  |  6 ++++-
- 7 files changed, 76 insertions(+), 80 deletions(-)
+ harness/main.js            | 13 ++++++++++--
+ harness/test.js            | 43 ++++++++++++--------------------------
+ harness/testView.js        | 39 +++++++++++++++++++++-------------
+ harness/timeout.js         |  9 ++++++++
+ style.css                  |  6 +++++-
+ 7 files changed, 76 insertions(+), 70 deletions(-)
 
 diff --git a/harness/compactTestView.js b/harness/compactTestView.js
 index 77f7b68..9bc41a7 100644
@@ -155,7 +155,7 @@ index c722460..21c0512 100644
    if (!testSuiteVersion.testSuites.indexOf(harnessConfig.testType) === -1) {
      alert('Cannot find test type ' + harnessConfig.testType);
 diff --git a/harness/test.js b/harness/test.js
-index b781e31..cc4ea4f 100644
+index b781e31..a0de08b 100644
 --- a/harness/test.js
 +++ b/harness/test.js
 @@ -1,6 +1,7 @@
@@ -269,23 +269,6 @@ index b781e31..cc4ea4f 100644
    this.updateStatus();
  
    this.timeouts.clearAll();
-@@ -566,16 +549,6 @@ window.getTestResults = function(testStartId, testEndId) {
-     fail: {}
-   };
- 
--  for (var r in results) {
--    results[r][harnessConfig.testSuite] = {};
--    results[r][harnessConfig.testSuite][harnessConfig.testType] = {};
--  }
--
--  var passResults =
--      results.pass[harnessConfig.testSuite][harnessConfig.testType];
--  var failResults =
--      results.fail[harnessConfig.testSuite][harnessConfig.testType];
--
-   for (var i = testStartId; i < testEndId; ++i) {
-     if (window.globalRunner.testList[i]) {
-       var test = window.globalRunner.testList[i];
 diff --git a/harness/testView.js b/harness/testView.js
 index c040757..640ba1b 100644
 --- a/harness/testView.js

--- a/patches/0001_js_mse_eme_mvt.patch
+++ b/patches/0001_js_mse_eme_mvt.patch
@@ -1,10 +1,9 @@
-From 9e5b57a8cd862b34f3327748e74ef0a85450964c Mon Sep 17 00:00:00 2001
-From: Lukasz Rutkowski <lukasz.rutkowski@consult.red>
-Date: Tue, 5 Jul 2022 17:08:55 +0200
-Subject: [PATCH] MVT changes
+From 2eb2e57c63fdf02d905425c8639dd507659abe92 Mon Sep 17 00:00:00 2001
+From: Maciej Kolanski <maciej.kolanski@consult.red>
+Date: Fri, 8 Jul 2022 12:07:08 +0200
+Subject: [PATCH] [PATCH] MVT changes
 
 * Load MVT tests instead of the upstream tests
-* Modify getTestResults format to one compatibile with Robot
 * Add execution logs to test results
 * Add checkFrames flag
 * Add clearTimeout method
@@ -12,16 +11,15 @@ Subject: [PATCH] MVT changes
 * Add engine (player) selectors
 * Remove some unsupported links
 * Add links to YouTube test suite and Media Coverage
-* Hide player version choices if not needed in selected testsuite
 ---
- harness/compactTestView.js | 33 +++++---------
- harness/constants.js       |  3 +-
- harness/main.js            | 13 +++++-
- harness/test.js            | 93 ++++++++++++++++----------------------
- harness/testView.js        | 39 ++++++++++------
- harness/timeout.js         |  9 ++++
- style.css                  |  6 ++-
- 7 files changed, 101 insertions(+), 95 deletions(-)
+ harness/compactTestView.js | 33 +++++++++---------------
+ harness/constants.js       |  3 ++-
+ harness/main.js            | 13 ++++++++--
+ harness/test.js            | 53 ++++++++++----------------------------
+ harness/testView.js        | 39 +++++++++++++++++-----------
+ harness/timeout.js         |  9 +++++++
+ style.css                  |  6 ++++-
+ 7 files changed, 76 insertions(+), 80 deletions(-)
 
 diff --git a/harness/compactTestView.js b/harness/compactTestView.js
 index 77f7b68..9bc41a7 100644
@@ -157,7 +155,7 @@ index c722460..21c0512 100644
    if (!testSuiteVersion.testSuites.indexOf(harnessConfig.testType) === -1) {
      alert('Cannot find test type ' + harnessConfig.testType);
 diff --git a/harness/test.js b/harness/test.js
-index b781e31..b20d03d 100644
+index b781e31..cc4ea4f 100644
 --- a/harness/test.js
 +++ b/harness/test.js
 @@ -1,6 +1,7 @@
@@ -271,33 +269,8 @@ index b781e31..b20d03d 100644
    this.updateStatus();
  
    this.timeouts.clearAll();
-@@ -557,41 +540,41 @@ TestExecutor.prototype.teardownCurrentTest = function(isTimeout, errorMsg) {
- window.TestBase = TestBase;
- window.TestExecutor = TestExecutor;
- 
-+function getTestStatus(test) {
-+  if (test.prototype.outcome == TestOutcome.PASSED)
-+    return "passed";
-+  else if (test.prototype.outcome == TestOutcome.FAILED)
-+    return "failed";
-+  else
-+    return "skipped";
-+}
-+
- window.getTestResults = function(testStartId, testEndId) {
-   testStartId = testStartId || 0;
-   testEndId = testEndId || window.globalRunner.testList.length;
- 
-   var results = {
--    pass: {},
--    fail: {}
-+    "name": harnessConfig.testType,
-+    "setup_log": "",
-+    "suites": [],
-+    "teardown_log": "",
-+    "tests": [],
-+    "type": "suite_result",
-+    "ver": "1.0"
+@@ -566,16 +549,6 @@ window.getTestResults = function(testStartId, testEndId) {
+     fail: {}
    };
  
 -  for (var r in results) {
@@ -313,31 +286,6 @@ index b781e31..b20d03d 100644
    for (var i = testStartId; i < testEndId; ++i) {
      if (window.globalRunner.testList[i]) {
        var test = window.globalRunner.testList[i];
--      var category = test.prototype.category;
--      var name = test.prototype.name;
--      if (test.prototype.failures > 0) {
--        if (!failResults[category]) {
--          failResults[category] = [];
--        }
--        failResults[category].push(name);
--      } else if (test.prototype.passes > 0) {
--        if (!passResults[category]) {
--          passResults[category] = [];
--        }
--        passResults[category].push(name);
--      }
-+      results["tests"].push({
-+        "log": test.prototype.logs,
-+        "name": test.prototype.name,
-+        "status": getTestStatus(test),
-+        "suites_chain": "MVT_SUITE." + harnessConfig.testType,
-+        "time_ms": test.prototype.executionTime,
-+        "type": "test_result",
-+        "ver": "1.0"
-+      });
-     }
-   }
-   return results;
 diff --git a/harness/testView.js b/harness/testView.js
 index c040757..640ba1b 100644
 --- a/harness/testView.js


### PR DESCRIPTION
|src/mvtTest.js| provides |getMvtTestResults|, which returns output in
expected, robot-like format. In that case there is no need to override
submodule's code.