### PR TITLE
[ONEM-26034] Use |innerText| for accessing dash.js subs content

### DIFF
--- a/src/engines.js
+++ b/src/engines.js
@@ -34,7 +34,7 @@ function extractSubtitleCue(content, callback) {
       var subtitlesDiv = document.getElementById("subtitles");
       var elements = subtitlesDiv.getElementsByTagName("div");
       for (var i = 0; i < elements.length; i++) {
-        callback(elements[i].textContent);
+        callback(elements[i].innerText);
       }
     } else {
       for (var i = 0; i < cues.length; i++) {

--- a/src/filterTest.js
+++ b/src/filterTest.js
@@ -29,7 +29,6 @@ var FilterTestList = {
   "DASH-MULTIPERIOD Playback": FilterTestEnum.OPTIONAL, // TODO(ONEM-26036)
   "DASH-MULTIPERIOD Pause": FilterTestEnum.OPTIONAL, // TODO(ONEM-26036)
   "DASH-MULTIPERIOD Position": FilterTestEnum.OPTIONAL, // TODO(ONEM-26036)
-  "DASH-FMP4-AVC1-AAC-TTML Subtitles": FilterTestEnum.OPTIONAL, // TODO(ONEM-26034)
   "DASH-FMP4-MULTIAUDIO AudioTracks": FilterTestEnum.OPTIONAL, // TODO(ONEM-26279)
   "PROG-MKV-EAC3 Position": FilterTestEnum.OPTIONAL,
   'audio/mp2t; codecs="mp4a.40.29"(aac)': FilterTestEnum.HIDDEN,


### PR DESCRIPTION
HTML node property |textContent| returns text without any whitespaces.
It leads to |DASH-FMP4-AVC1-AAC-TTML Subtitles| failures on dash.js,
because the returned value is verified against expected text which
inluced '\n' character.

Usage of |innerText| property solves the above issue.