### PR TITLE
[ONEM-27992] Enable testsuite dash-html5-test for default profile

### DIFF
--- a/coverage.html
+++ b/coverage.html
@@ -26,7 +26,6 @@ limitations under the License.
     <script type="text/javascript" async defer>
       // Do NOT Change order of script sources!
       var scriptSources = [
-        "https://cdn.jsdelivr.net/npm/hls.js@latest",
         "js_mse_eme/harness/util.js",
         "js_mse_eme/harness/constants.js",
         "js_mse_eme/harness/key.js",

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ limitations under the License.
       var scriptSources = [
         // Required by Shaka Player to support MPEG-2 TS
         "https://cdnjs.cloudflare.com/ajax/libs/mux.js/5.10.0/mux.min.js",
-        "https://cdn.jsdelivr.net/npm/hls.js@latest",
+        "https://cdn.jsdelivr.net/npm/hls.js@1.2.1",
         "js_mse_eme/harness/util.js",
         "js_mse_eme/harness/constants.js",
         "js_mse_eme/harness/key.js",

--- a/mediaStreams.js
+++ b/mediaStreams.js
@@ -233,6 +233,17 @@ var MS = {
         codec: "eac3",
       },
     },
+    CMAF_AVC_MP3: {
+      variant: "dash",
+      container: "cmaf",
+      src: "test-materials/cmaf/h264_mp3/manifest.mpd",
+      video: {
+        codec: "avc",
+      },
+      audio: {
+        codec: "mp3",
+      },
+    },
     CMAF_AVC_MP3_VTT: {
       variant: "dash",
       container: "cmaf",
@@ -689,7 +700,7 @@ const StreamSets = {
       MS.DASH.DYNAMIC,
       MS.DASH.CMAF_AVC_AC3,
       MS.DASH.CMAF_HEVC_EAC3,
-      MS.DASH.CMAF_AVC_MP3_VTT,
+      MS.DASH.CMAF_AVC_MP3,
     ],
     DRM: [MS.DASH.PLAYREADY_2_0],
     Subtitles: [MS.DASH.FMP4_AVC_AAC_TTML, MS.DASH.WEBM_VP9_OPUS_VTT, MS.DASH.CMAF_AVC_MP3_VTT],

--- a/src/coverage.js
+++ b/src/coverage.js
@@ -56,22 +56,16 @@ function createAndAdd(parent, tag, content) {
 }
 
 function setCoverageHeader(coverageDiv) {
-  coverageDiv.innerHTML =
-    "<p>Coverage report for profile: " +
-    SelectedProfile.note +
-    '</p>\
-  <p>This lists how many pieces of test content exist, not if the content pass or fail.</p>\
-  <table><tr>\
-  <td style="background-color:' +
-    unsupportedColor +
-    '">Unsupported</td>\
-  <td style="background-color:' +
-    noContentColor +
-    '">Supported, No Content</td>\
-  <td style="background-color:' +
-    someContentColor +
-    '">Supported and number of tests</td>\
-  </tr></table>';
+  coverageDiv.innerHTML = `
+    <p>Coverage report for profile: <b>${SelectedProfile.note}</b></p>
+    <p>This lists how many pieces of test content exist, not if the content pass or fail.</p>
+    <table>
+      <tr>
+        <td style="background-color: ${unsupportedColor}">Unsupported</td>
+        <td style="background-color: ${noContentColor}">Supported, No Content</td>
+        <td style="background-color: ${someContentColor}">Supported and number of tests</td>
+      </tr>
+    </table>`;
 }
 
 function addProfileSelector(coverageDiv) {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -49,7 +49,7 @@ const Profiles = {
     note: "Default",
     drm: ["com.microsoft.playready"],
     codecs: ["avc", "hevc", "mpeg2", "vp9", "aac", "ac3", "eac3", "mp3", "opus"],
-    native_support: ["hss", "progressive"],
+    native_support: ["dash", "hss", "progressive"],
   },
   desktop: {
     note: "For desktop browsers",
@@ -68,6 +68,6 @@ const EngineProperties = {
   hlsjs: { variants: ["hls"], subtitles: ["vtt"] },
   html5: {
     variants: SelectedProfile.native_support,
-    subtitles: [],
+    subtitles: ["ttml", "vtt"],
   },
 };

--- a/src/suites.js
+++ b/src/suites.js
@@ -116,13 +116,29 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let engine = new Html5Engine();
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
+  StreamSets.DASH.html5 = StreamSets.DASH.Common.filter((stream) => {
+    return stream != MS.DASH.WEBM_VP9_OPUS && stream != MS.DASH.DYNAMIC && stream != MS.DASH.FMP4_HEVC_EAC3 // ONEM-27782
+  })
 
-  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.Common);
-  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.Common));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.Common));
-  // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.Video, new Unstable("ONEM-26268")));
+  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.html5);
+  tests.push(new MvtMediaTest(testPlayback, MS.DASH.WEBM_VP9_OPUS, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testPlayback, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testPlayback, MS.DASH.FMP4_HEVC_EAC3, engine));
+
+  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.html5));
+  tests.push(new MvtMediaTest(testPause, MS.DASH.WEBM_VP9_OPUS, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testPause, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testPause, MS.DASH.FMP4_HEVC_EAC3, engine, new Unstable("ONEM-27782")));
+
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.html5));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.WEBM_VP9_OPUS, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.FMP4_HEVC_EAC3, engine));
+
+  // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.html5, new Unstable("ONEM-26268")));
+  tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles, new Unstable("ONEM-27782")));
+
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.DASH.MULTIAUDIO, engine));
-  tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles));
 
   tests = filterUnsupportedOnProfile(SelectedProfile, tests);
   tests = filterSkipTests(skipTests, tests);


### PR DESCRIPTION
* enabled testsuite dash-html5-test for default profile,
* hls.js player version hardcoded to "1.2.1", was "latest". Reason: [ONEM-28050]