### PR TITLE
[security] Remove access for browsing source files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git*
+.cache
+env
+venv
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 .git*
+*.md
+docs
 .cache
 env
 venv

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond %{HTTP_HOST}@@%{HTTP_REFERER} !^([^@]*)@@https?://\1/.*
+RewriteRule \.(js|ts|py|sh|conf|config|patch|m4s|mp3|mp4|mkv|mpd|m3u8|webm|vtt|ttml)$ - [F]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,12 @@
 # limitations under the License.
 
 FROM httpd:latest
-RUN sed -i 's/Options Indexes FollowSymLinks/Options FollowSymLinks/' /usr/local/apache2/conf/httpd.conf
+COPY httpd.conf /usr/local/apache2/conf/httpd.conf
 
-ARG MVT_PATH=/usr/local/apache2/htdocs
+ARG MVT_PATH=/home/MVT
 ENV MVT_PATH=$MVT_PATH
 
+RUN mkdir -p $MVT_PATH
 COPY . $MVT_PATH
 WORKDIR $MVT_PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 FROM httpd:latest
+RUN sed -i 's/Options Indexes FollowSymLinks/Options FollowSymLinks/' /usr/local/apache2/conf/httpd.conf
 
 ARG MVT_PATH=/usr/local/apache2/htdocs
 ENV MVT_PATH=$MVT_PATH

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ It is still supported, but it uses different output format and does not include 
 3. Start development container with:
 
 ```
-docker run -v $PWD/:/usr/local/apache2/htdocs -v $TEST_MATERIALS_SRC:/usr/local/apache2/htdocs/test-materials -p 8080:80 --rm -d -it --name mvt-app mvt-app-img:latest
+docker run -v $PWD/:/home/MVT -v $TEST_MATERIALS_SRC:/home/MVT/test-materials -p 8080:80 --rm -d -it --name mvt-app mvt-app-img:latest
 ```
 
 Now you can modify MVT source code and observe changes on: http://localhost:8080/

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -18,4 +18,4 @@
 # limitations under the License.
 
 mkdir -p ${TEST_MATERIALS_SRC:-/data/test-materials}
-docker run -v ${TEST_MATERIALS_SRC:-/data/test-materials}:/usr/local/apache2/htdocs/test-materials --rm -d -it --name mvt-app -p ${PORT:-80}:80 mvt-app-img
+docker run -v ${TEST_MATERIALS_SRC:-/data/test-materials}:/home/MVT/test-materials --rm -d -it --name mvt-app -p ${PORT:-80}:80 mvt-app-img

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,0 +1,87 @@
+#
+# This is the main Apache HTTP server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.4/> for detailed information.
+#
+
+ServerRoot "/usr/local/apache2"
+Listen 80
+Listen 443
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule access_compat_module modules/mod_access_compat.so
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule reqtimeout_module modules/mod_reqtimeout.so
+LoadModule filter_module modules/mod_filter.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule env_module modules/mod_env.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule version_module modules/mod_version.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule rewrite_module modules/mod_rewrite.so
+
+<IfModule unixd_module>
+    User www-data
+    Group www-data
+</IfModule>
+
+<Directory />
+    AllowOverride none
+    Require all denied
+</Directory>
+
+DocumentRoot "/home/MVT"
+<Directory "/home/MVT">
+    Options FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>
+
+<Files ".ht*">
+    Require all denied
+</Files>
+
+ErrorLog /proc/self/fd/2
+LogLevel warn
+
+<IfModule log_config_module>
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    LogFormat "%h %l %u %t \"%r\" %>s %b" common
+    CustomLog /proc/self/fd/1 common
+</IfModule>
+
+<IfModule alias_module>
+    ScriptAlias /cgi-bin/ "/usr/local/apache2/cgi-bin/"
+</IfModule>
+
+<Directory "/usr/local/apache2/cgi-bin">
+    AllowOverride none
+    Options None
+    Require all granted
+</Directory>
+
+<IfModule headers_module>
+    RequestHeader unset Proxy early
+</IfModule>
+
+<IfModule mime_module>
+    TypesConfig conf/mime.types
+    AddType application/x-compress .Z
+    AddType application/x-gzip .gz .tgz
+</IfModule>


### PR DESCRIPTION
- Disable access for browsing source files via web browser,
- Do not include git files in the docker image,
- Change MVT directory from "/usr/local/apache2/htdocs" to "/home/MVT",
- Add httpd.conf, .dockerignore and .htaccess files.