### PR TITLE
Correct tests to be marked as stable or unstable

### DIFF
--- a/mediaStreams.js
+++ b/mediaStreams.js
@@ -272,7 +272,6 @@ var MS = {
       audio: {
         codec: "aac",
       },
-      unstable: new Unstable("ONEM-28049"),
     },
     FMP4_AVC_EAC3: {
       variant: "hls",

--- a/src/suites.js
+++ b/src/suites.js
@@ -78,10 +78,14 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let engine = new ShakaEngine();
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
+  StreamSets.DASH.shaka = StreamSets.DASH.CommonAndDRM.filter((stream) => {
+    return stream != MS.DASH.FMP4_MP3; // ONEM-29179
+  });
 
   let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.CommonAndDRM);
   tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.CommonAndDRM));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.CommonAndDRM));
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.shaka));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.FMP4_MP3, engine, new Unstable("ONEM-29179")));
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.Video, new Unstable("ONEM-26268")));
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.DASH.MULTIAUDIO, engine, new Unstable("ONEM-26279")));
   tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles));
@@ -178,10 +182,16 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let engine = new HlsjsEngine();
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
+  StreamSets.HLS.hlsjs = StreamSets.HLS.Common.filter((stream) => {
+    return stream != MS.HLS.MP2TS_AVC_AAC; // ONEM-28049
+  });
 
-  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.HLS.Common);
-  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.HLS.Common));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.HLS.Common));
+  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.HLS.hlsjs);
+  tests.push(new MvtMediaTest(testPlayback, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
+  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.HLS.hlsjs));
+  tests.push(new MvtMediaTest(testPause, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.HLS.hlsjs));
+  tests.push(new MvtMediaTest(testSetPosition, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
   // TODO: ONEM-26268 Fix Rate tests
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.HLS.Video, new Unstable("ONEM-26268")));
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.HLS.FMP4_MULTIAUDIO, engine));
@@ -245,7 +255,7 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.Progressive.Common);
   tests.push(new MvtMediaTest(testPlayback, MS.PROG.MKV_EAC3, engine));
   tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.Progressive.Common));
-  tests.push(new MvtMediaTest(testPause, MS.PROG.MKV_EAC3, engine, new Unstable("ARRISEOS-42467")));
+  tests.push(new MvtMediaTest(testPause, MS.PROG.MKV_EAC3, engine));
   tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.Progressive.Common));
   tests.push(new MvtMediaTest(testSetPosition, MS.PROG.MKV_EAC3, engine, new Unstable("ONEM-26126")));
   // tests = tests.concat(


### PR DESCRIPTION
Mark tests HLS_SHAKA_MP2TS_AVC_AAC Playback Pause and Seek as mandatory.
Mark test PROG_MKV_EAC3 Pause as mandatory.
Mark test DAH_SHAKA_FMP4_MP3 Seek as unstable due to ONEM-29179.