### PR TITLE
Add PlayReady 4.0 test, upgrade default versions for HLS.js and Dash.js players

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ A list of of all external media assets used by a deployed instance of MVT:
 | HLS-CMAF-AVC1-AAC  | [DASH IF](https://testassets.dashif.org/)                                        | https://media.axprod.net/TestVectors/v9-MultiFormat/Clear/Manifest_1080p.m3u8                                                                 | Not distributed by MVT, used for playback during test execution                                                                             |
 | HLS-CMAF-HEVC-AAC  | [DASH IF](https://testassets.dashif.org/)                                        | https://dash.akamaized.net/dash264/TestCasesIOP41/CMAF/UnifiedStreaming/ToS_HEVC_MultiRate_MultiRes_IFrame_AAC_WebVTT.m3u8                    | Not distributed by MVT, used for playback during test execution                                                                             |
 | DASH-PLAYREADY-2.0 | [Microsoft PlayReady](https://testweb.playready.microsoft.com/Content/Content2X) | http://profficialsite.origin.mediaservices.windows.net/c51358ea-9a5e-4322-8951-897d640fdfd7/tearsofsteel_4k.ism/manifest(format=mpd-time-csf) | Not distributed by MVT, used for playback during test execution                                                                             |
+| DASH-PLAYREADY-4.0 | [DASH IF](https://testassets.dashif.org/)                                        | https://media.axprod.net/TestVectors/Cmaf/protected_1080p_h264_cbcs/manifest.mpd                                                              | Not distributed by MVT, used for playback during test execution                                                                             |
 | HSS-AVC1-AAC       | [Microsoft PlayReady](https://testweb.playready.microsoft.com/Content/Content2X) | http://amssamples.streaming.mediaservices.windows.net/683f7e47-bd83-4427-b0a3-26a6c4547782/BigBuckBunny.ism/manifest(format=mpd-time-csf)     | Not distributed by MVT, used for playback during test execution                                                                             |
 | HSS-AVC1-AAC       | [Microsoft PlayReady](https://testweb.playready.microsoft.com/Content/Content2X) | http://profficialsite.origin.mediaservices.windows.net/c51358ea-9a5e-4322-8951-897d640fdfd7/tearsofsteel_4k.ism/manifest                      | Not distributed by MVT, used for playback during test execution                                                                             |
 
@@ -152,9 +153,9 @@ Most of the URL parameters can be combined. Here's a full list of supported quer
 - `loop=false|true` - enable testing selected tests continuosly in a loop.
 - `stoponfailure=false|true` - tests execution will stop on the first failed test.
 - `disable_log=false|true` - enable/disable logging.
-- `engine_shaka=2.5.20|3.0.1|3.2.1` - select Shaka Player version. Please note it will only affect Shaka test suites.
-- `engine_dashjs=2.9.3|3.1.1|4.4.0|latest` - select dash.js version. Please note it will only affect dash.js test suites.
-- `engine_hlsjs=1.0.0|1.1.5|1.2.1|1.2.9|1.3.0` - select hls.js version. Please note it will only affect hls.js test suites.
+- `engine_shaka=3.0.1|3.2.1|4.3.6` - select Shaka Player version. Please note it will only affect Shaka test suites.
+- `engine_dashjs=3.1.1|4.4.0|4.7.0|latest` - select dash.js version. Please note it will only affect dash.js test suites.
+- `engine_hlsjs=1.0.0|1.2.1|1.3.0|1.4.5` - select hls.js version. Please note it will only affect hls.js test suites.
 - `profile=all|default|desktop|VIP7002W` - depends of tested unit.
 - `debug=true|false` - adding additional timestamps to the output log.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Most of the URL parameters can be combined. Here's a full list of supported quer
 - `engine_shaka=2.5.20|3.0.1|3.2.1` - select Shaka Player version. Please note it will only affect Shaka test suites.
 - `engine_dashjs=2.9.3|3.1.1|4.4.0|latest` - select dash.js version. Please note it will only affect dash.js test suites.
 - `engine_hlsjs=1.0.0|1.1.5|1.2.1|1.2.9|1.3.0` - select hls.js version. Please note it will only affect hls.js test suites.
+- `profile=all|default|desktop|VIP7002W` - depends of tested unit.
+- `debug=true|false` - adding additional timestamps to the output log.
 
 ### JavaScript API
 

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,67 +20,38 @@ limitations under the License.
     <title>Media Validation Tool</title>
     <link rel="stylesheet" href="js_mse_eme/style.css" type="text/css" />
     <link rel="stylesheet" href="style.css" type="text/css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mux.js/6.2.0/mux.min.js" defer></script>
+    <!-- Do NOT Change order of script sources! -->
+    <script src="src/engineChange.js" defer></script>
+    <script src="test-materials/js/countdown-de.js" defer></script>
+    <script src="test-materials/js/countdown-en.js" defer></script>
+    <script src="test-materials/js/countdown-fr.js" defer></script>
+    <script src="test-materials/js/countdown-es.js" defer></script>
+    <script src="src/constants.js" defer></script>
+    <script src="src/common.js" defer></script>
+    <script src="mediaStreams.js" defer></script>
+    <script src="js_mse_eme/harness/util.js" defer></script>
+    <script src="js_mse_eme/harness/constants.js" defer></script>
+    <script src="js_mse_eme/harness/key.js" defer></script>
+    <script src="js_mse_eme/harness/focusManager.js" defer></script>
+    <script src="js_mse_eme/harness/logger.js" defer></script>
+    <script src="js_mse_eme/harness/xhr.js" defer></script>
+    <script src="js_mse_eme/harness/timeout.js" defer></script>
+    <script src="js_mse_eme/harness/testView.js" defer></script>
+    <script src="js_mse_eme/harness/compactTestList.js" defer></script>
+    <script src="js_mse_eme/harness/compactTestView.js" defer></script>
+    <script src="js_mse_eme/harness/test.js" defer></script>
+    <script src="js_mse_eme/lib/mse/msutil.js" defer></script>
+    <script src="js_mse_eme/lib/mse/mediaSourcePortability.js" defer></script>
+    <script src="src/mvtTest.js" defer></script>
+    <script src="src/profiles.js" defer></script>
+    <script src="src/engines.js" defer></script>
+    <script src="src/mediaTests.js" defer></script>
+    <script src="src/suites.js" defer></script>
+    <script src="js_mse_eme/harness/main.js" defer></script>
   </head>
   <body>
     <div id="testArea" style="display: none"></div>
-    <script type="text/javascript" async defer>
-      // Do NOT Change order of script sources!
-      var scriptSources = [
-        // Required by Shaka Player to support MPEG-2 TS
-        "https://cdnjs.cloudflare.com/ajax/libs/mux.js/6.2.0/mux.min.js",
-        "src/engineChange.js",
-        "js_mse_eme/harness/util.js",
-        "js_mse_eme/harness/constants.js",
-        "js_mse_eme/harness/key.js",
-        "js_mse_eme/harness/focusManager.js",
-        "js_mse_eme/harness/logger.js",
-        "js_mse_eme/harness/xhr.js",
-        "js_mse_eme/harness/timeout.js",
-        "js_mse_eme/harness/testView.js",
-        "js_mse_eme/harness/compactTestList.js",
-        "js_mse_eme/harness/compactTestView.js",
-        "js_mse_eme/harness/test.js",
-        "js_mse_eme/lib/mse/msutil.js",
-        "js_mse_eme/lib/mse/mediaSourcePortability.js",
-        "test-materials/js/countdown-de.js",
-        "test-materials/js/countdown-en.js",
-        "test-materials/js/countdown-fr.js",
-        "test-materials/js/countdown-es.js",
-        "src/constants.js",
-        "src/common.js",
-        "mediaStreams.js",
-        "src/mvtTest.js",
-        "src/profiles.js",
-        "src/engines.js",
-        "src/mediaTests.js",
-        "src/suites.js",
-        "js_mse_eme/harness/main.js",
-      ];
-      /*
-       * Load each script sequentially but marked as async so cobalt is able to pause/suspend
-       * the loading of YTS scripts and return later to finish executing
-       */
-      (function loadNextScript() {
-        if (scriptSources.length) {
-          var script = document.createElement("script");
-          script.src = scriptSources[0];
-          script.async = true;
-          script.defer = true;
-          script.onload = function () {
-            scriptSources.shift();
-            loadNextScript();
-          };
-          script.onerror = function () {
-            console.error("Failed to load ", scriptSources[0]);
-            scriptSources.shift();
-            loadNextScript();
-          };
-          document.head.appendChild(script);
-        } else {
-          startMseTest(testVersion);
-        }
-      })();
-    </script>
     <div id="login-pop-up" style="display: none">
       <div id="client-id-div">
         <p class="step">1) On your phone or computer, go to youtube.com/activate</p>
@@ -90,5 +61,10 @@ limitations under the License.
         <p class="step">3) Sign in with your Google account</p>
       </div>
     </div>
+    <script type="text/javascript">
+      window.addEventListener('load', function() {
+        startMseTest(testVersion);
+      })
+    </script>
   </body>
 </html>

--- a/mediaStreams.js
+++ b/mediaStreams.js
@@ -186,6 +186,30 @@ var MS = {
         },
       },
     },
+    PLAYREADY_4_0_CBCS: {
+      variant: "dash",
+      container: "fmp4",
+      note: "PLayReady 4.0 with CBCS encryption",
+      video: {
+        codec: "avc",
+      },
+      audio: {
+        codec: "aac",
+      },
+      src: "https://media.axprod.net/TestVectors/Cmaf/protected_1080p_h264_cbcs/manifest.mpd",
+      drm: {
+        servers: {
+          "com.microsoft.playready": {
+            "serverURL": "https://drm-playready-licensing.axprod.net/AcquireLicense",
+            "httpRequestHeaders": {
+                "X-AxDRM-Message": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.ewogICJ2ZXJzaW9uIjogMSwKICAiY29tX2tleV9pZCI6ICI2OWU1NDA4OC1lOWUwLTQ1MzAtOGMxYS0xZWI2ZGNkMGQxNGUiLAogICJtZXNzYWdlIjogewogICAgInR5cGUiOiAiZW50aXRsZW1lbnRfbWVzc2FnZSIsCiAgICAidmVyc2lvbiI6IDIsCiAgICAibGljZW5zZSI6IHsKICAgICAgImFsbG93X3BlcnNpc3RlbmNlIjogdHJ1ZQogICAgfSwKICAgICJjb250ZW50X2tleXNfc291cmNlIjogewogICAgICAiaW5saW5lIjogWwogICAgICAgIHsKICAgICAgICAgICJpZCI6ICIzMDJmODBkZC00MTFlLTQ4ODYtYmNhNS1iYjFmODAxOGEwMjQiLAogICAgICAgICAgImVuY3J5cHRlZF9rZXkiOiAicm9LQWcwdDdKaTFpNDNmd3YremZ0UT09IiwKICAgICAgICAgICJ1c2FnZV9wb2xpY3kiOiAiUG9saWN5IEEiCiAgICAgICAgfQogICAgICBdCiAgICB9LAogICAgImNvbnRlbnRfa2V5X3VzYWdlX3BvbGljaWVzIjogWwogICAgICB7CiAgICAgICAgIm5hbWUiOiAiUG9saWN5IEEiLAogICAgICAgICJwbGF5cmVhZHkiOiB7CiAgICAgICAgICAibWluX2RldmljZV9zZWN1cml0eV9sZXZlbCI6IDE1MCwKICAgICAgICAgICJwbGF5X2VuYWJsZXJzIjogWwogICAgICAgICAgICAiNzg2NjI3RDgtQzJBNi00NEJFLThGODgtMDhBRTI1NUIwMUE3IgogICAgICAgICAgXQogICAgICAgIH0KICAgICAgfQogICAgXQogIH0KfQ._NfhLVY7S6k8TJDWPeMPhUawhympnrk6WAZHOVjER6M"
+            }
+          }
+        }
+      },
+      cbcs: true,
+      unstable: new Unstable("PlayReady 4.0 CBCS in implementation state"),
+    },
     DYNAMIC: {
       variant: "dash",
       container: "fmp4",
@@ -703,6 +727,7 @@ const StreamSets = {
       MS.DASH.CMAF_AVC_MP3,
     ],
     DRM: [MS.DASH.PLAYREADY_2_0],
+    DRM_CBCS: [MS.DASH.PLAYREADY_4_0_CBCS],
     Subtitles: [MS.DASH.FMP4_AVC_AAC_TTML, MS.DASH.WEBM_VP9_OPUS_VTT, MS.DASH.CMAF_AVC_MP3_VTT],
   },
   HLS: {
@@ -747,6 +772,7 @@ const StreamSets = {
 (function () {
   StreamSets.DASH.Video = StreamSets.DASH.Common.filter((stream) => stream.video);
   StreamSets.DASH.CommonAndDRM = StreamSets.DASH.Common.concat(StreamSets.DASH.DRM);
+  StreamSets.DASH.CommonAndDRMCBCS = StreamSets.DASH.Common.concat(StreamSets.DASH.DRM).concat(StreamSets.DASH.DRM_CBCS);
   StreamSets.HLS.Video = StreamSets.HLS.Common.filter((stream) => stream.video);
   StreamSets.Progressive.Video = StreamSets.Progressive.Common.filter((stream) => stream.video);
 })();

--- a/mediaStreams.js
+++ b/mediaStreams.js
@@ -208,7 +208,6 @@ var MS = {
         }
       },
       cbcs: true,
-      unstable: new Unstable("PlayReady 4.0 CBCS in implementation state"),
     },
     DYNAMIC: {
       variant: "dash",

--- a/patches/0001_js_mse_eme_mvt.patch
+++ b/patches/0001_js_mse_eme_mvt.patch
@@ -126,11 +126,12 @@ index c722460..af1fec6 100644
      testName = util.MakeCapitalName(testName) + 'Test';
      return window[testName]();
    }
-@@ -51,6 +56,7 @@ var parseParams = function(testSuiteConfig) {
+@@ -51,6 +56,8 @@ var parseParams = function(testSuiteConfig) {
        parseParam('stoponfailure', false));
    config.enablewebm = util.stringToBoolean(
        parseParam('enablewebm', testSuiteConfig.enablewebm));
 +  config.checkframes = util.stringToBoolean(parseParam('checkframes', false));
++  config.debug = util.stringToBoolean(parseParam('debug', false));
    config.muted = util.stringToBoolean(parseParam('muted', false));
    config.novp9 = util.stringToBoolean(parseParam('novp9', false));
    config.tests = parseParam('tests');
@@ -176,7 +177,7 @@ index c722460..af1fec6 100644
      runner.startTest(0, runner.testList.length);
 +  }
 +  if (harnessConfig.command === 'run') {
-+    waitForScriptLoad(2).then(runTest)
++    waitForScriptLoad(3).then(runTest)
 +  }
  };
  

--- a/src/engineChange.js
+++ b/src/engineChange.js
@@ -22,33 +22,32 @@
 var EngineVersions = {
   shaka: {
     versions: {
-      "2.5.20": ["https://ajax.googleapis.com/ajax/libs/shaka-player/2.5.20/shaka-player.compiled.js"],
       "3.0.1": ["https://ajax.googleapis.com/ajax/libs/shaka-player/3.0.1/shaka-player.compiled.js"],
       "3.2.1": ["https://ajax.googleapis.com/ajax/libs/shaka-player/3.2.1/shaka-player.compiled.js"],
+      "4.3.6": ["https://ajax.googleapis.com/ajax/libs/shaka-player/4.3.6/shaka-player.compiled.js"],
     },
     name: "Shaka Player",
     defaultVersion: "3.2.1",
   },
   dashjs: {
     versions: {
-      "2.9.3": ["https://cdn.dashjs.org/v2.9.3/dash.all.min.js", "https://cdn.dashjs.org/v2.9.3/dash.mss.min.js"],
       "3.1.1": ["https://cdn.dashjs.org/v3.1.1/dash.all.min.js", "https://cdn.dashjs.org/v3.1.1/dash.mss.min.js"],
       "4.4.0": ["https://cdn.dashjs.org/v4.4.0/dash.all.min.js", "https://cdn.dashjs.org/v4.4.0/dash.mss.min.js"],
+      "4.7.0": ["https://cdn.dashjs.org/v4.7.0/dash.all.min.js", "https://cdn.dashjs.org/v4.7.0/dash.mss.min.js"],
       latest: ["https://cdn.dashjs.org/latest/dash.all.min.js", "https://cdn.dashjs.org/latest/dash.mss.min.js"],
     },
     name: "Dash.JS",
-    defaultVersion: "4.4.0",
+    defaultVersion: "4.7.0",
   },
   hlsjs: {
     versions: {
       "1.0.0": ["https://cdn.jsdelivr.net/npm/hls.js@1.0.0"],
-      "1.1.5": ["https://cdn.jsdelivr.net/npm/hls.js@1.1.5"],
       "1.2.1": ["https://cdn.jsdelivr.net/npm/hls.js@1.2.1"],
-      "1.2.9": ["https://cdn.jsdelivr.net/npm/hls.js@1.2.9"],
       "1.3.0": ["https://cdn.jsdelivr.net/npm/hls.js@1.3.0"],
+      "1.4.5": ["https://cdn.jsdelivr.net/npm/hls.js@1.4.5"],
     },
     name: "HLS.js",
-    defaultVersion: "1.3.0",
+    defaultVersion: "1.4.5",
   },
 };
 
@@ -91,7 +90,7 @@ function loadStoredEngine() {
         if (scriptSources.length) {
           var script = document.createElement("script");
           script.src = scriptSources[0];
-          script.async = script.defer = true;
+          script.defer = true;
           script.onload = function () {
             scriptSources.shift();
             loadNextScript();

--- a/src/engines.js
+++ b/src/engines.js
@@ -198,14 +198,11 @@ class DashjsEngine extends Engine {
         that.onload(runner, video);
       });
 
-      if (media.drm) {
-        var protection = {};
-        for (var key in media.drm) {
-          protection[key] = { serverURL: media.drm[key] };
-        }
-        this.dashjsPlayer.setProtectionData(protection);
-      }
       this.dashjsPlayer.initialize(video, media.src, false);
+
+      if (media.drm) {
+        this.dashjsPlayer.setProtectionData(media.drm.servers);
+      }
 
       // Add subtitles div
       var subtitleDiv = document.createElement("div");

--- a/src/mediaTests.js
+++ b/src/mediaTests.js
@@ -37,6 +37,9 @@ function waitForEvent(video, runner, event, predicate = null, maxWaitTimeMs = 10
     }, maxWaitTimeMs);
 
     function eventHandler() {
+      if (harnessConfig.debug) {
+        runner.log("current time: " + video.currentTime)
+      }
       if (!predicate || predicate(video)) {
         receivedEvents += 1;
         if (receivedEvents >= times) {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -34,13 +34,14 @@ function filterUnsupportedOnProfile(profile, tests) {
     let videoSupported = !stream.video || profile.codecs.includes(stream.video.codec);
     let audioSupported = !stream.audio || profile.codecs.includes(stream.audio.codec);
     let drmSupported = !stream.drm || Object.keys(stream.drm.servers).some((drm) => profile.drm.includes(drm));
-    return variantSupported && videoSupported && audioSupported && drmSupported;
+    let cbcsSupported = stream.cbcs ? profile.note.includes("CBCS") : true;
+    return variantSupported && videoSupported && audioSupported && drmSupported && cbcsSupported;
   });
 }
 
 const Profiles = {
   all: {
-    note: "Everything enabled",
+    note: "Everything enabled, CBCS included",
     drm: ["com.microsoft.playready"],
     codecs: ["avc", "hevc", "mpeg2", "mpeg4part2", "vp9", "aac", "ac3", "eac3", "mp3", "opus"],
     native_support: ["dash", "hls", "hss", "progressive"],
@@ -57,15 +58,31 @@ const Profiles = {
     codecs: ["avc", "mpeg4part2", "vp9", "aac", "mp3", "opus"],
     native_support: ["progressive"],
   },
+  VIP7002W: {
+    note: "Default with CBCS support",
+    drm: ["com.microsoft.playready"],
+    codecs: ["avc", "hevc", "mpeg2", "vp9", "aac", "ac3", "eac3", "mp3", "opus"],
+    native_support: ["dash", "hss", "progressive"],
+  },
 };
 
-window.ConfigString = parseParam("profile", null) || window.localStorage["profile"] || "default";
-const SelectedProfile = Profiles[window.ConfigString] == undefined ? Profiles["default"] : Profiles[window.ConfigString];
+let getProfile = parseParam("profile", null) || window.localStorage["profile"] || "default";
+const SelectedProfile = Profiles[getProfile] == undefined ? Profiles["default"] : Profiles[getProfile];
+window.ConfigString = Profiles[getProfile] == undefined ? "default" : getProfile;
 
 const EngineProperties = {
-  shaka: { variants: ["dash", "hls"], subtitles: ["ttml", "vtt"] },
-  dashjs: { variants: ["dash", "hss"], subtitles: ["ttml", "vtt"] },
-  hlsjs: { variants: ["hls"], subtitles: ["vtt"] },
+  shaka: {
+    variants: ["dash", "hls"],
+    subtitles: ["ttml", "vtt"],
+  },
+  dashjs: {
+    variants: ["dash", "hss"],
+    subtitles: ["ttml", "vtt"],
+  },
+  hlsjs: {
+    variants: ["hls"],
+    subtitles: ["vtt"],
+  },
   html5: {
     variants: SelectedProfile.native_support,
     subtitles: ["ttml", "vtt"],

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -58,7 +58,7 @@ const Profiles = {
     codecs: ["avc", "mpeg4part2", "vp9", "aac", "mp3", "opus"],
     native_support: ["progressive"],
   },
-  VIP7002W: {
+  extended_drm: {
     note: "Default with CBCS support",
     drm: ["com.microsoft.playready"],
     codecs: ["avc", "hevc", "mpeg2", "vp9", "aac", "ac3", "eac3", "mp3", "opus"],

--- a/src/suites.js
+++ b/src/suites.js
@@ -182,16 +182,10 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let engine = new HlsjsEngine();
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
-  StreamSets.HLS.hlsjs = StreamSets.HLS.Common.filter((stream) => {
-    return stream != MS.HLS.MP2TS_AVC_AAC; // ONEM-28049
-  });
 
-  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.HLS.hlsjs);
-  tests.push(new MvtMediaTest(testPlayback, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
-  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.HLS.hlsjs));
-  tests.push(new MvtMediaTest(testPause, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.HLS.hlsjs));
-  tests.push(new MvtMediaTest(testSetPosition, MS.HLS.MP2TS_AVC_AAC, engine, new Unstable("ONEM-28049")));
+  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.HLS.Common);
+  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.HLS.Common));
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.HLS.Common));
   // TODO: ONEM-26268 Fix Rate tests
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.HLS.Video, new Unstable("ONEM-26268")));
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.HLS.FMP4_MULTIAUDIO, engine));

--- a/src/suites.js
+++ b/src/suites.js
@@ -102,9 +102,9 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
 
-  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.CommonAndDRM);
-  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.CommonAndDRM));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.CommonAndDRM));
+  let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.CommonAndDRMCBCS);
+  tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.CommonAndDRMCBCS));
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.CommonAndDRMCBCS));
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.Video, new Unstable("ONEM-26268")));
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.DASH.MULTIAUDIO, engine));
   tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles));


### PR DESCRIPTION
- DASH PlayReady 4.0 CBCS test added [ONEM-25815],
- HLS.js player upgrade from 1.3.0 to 1.4.5 [ONEM-31111]
- Dash.js player upgrade from 4.4.0 to 4.7.0
- Set HLS.MP2TS_AVC_AAC as mandatory [ONEM-28092]
- libraries import moved from script in 'body' to the 'head' section in index.html