### PR TITLE
Set some MULTIPERIOD tests back as stable and mandatory

### DIFF
--- a/src/mediaStreams.js
+++ b/src/mediaStreams.js
@@ -297,7 +297,6 @@ var MS = {
       audio: {
         codec: "aac",
       },
-      unstable: new Unstable("ONEM-26036"),
     },
     CMAF_AVC_AC3: {
       variant: "dash",

--- a/src/suites.js
+++ b/src/suites.js
@@ -105,10 +105,16 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let engine = new DashjsEngine();
   // in 'skipTests' specify test name as key and reason as value, e.g.: "DASH_FMP4_MP3 Seek": "ONEM-12345"
   let skipTests = {};
+  StreamSets.DASH.dashjs = StreamSets.DASH.CommonAndDRM.filter((stream) => {
+    return (
+      stream != MS.MULTIPERIOD // ONEM-31620
+    );
+  });
 
   let tests = makeMvtMediaTests(testPlayback, engine, StreamSets.DASH.CommonAndDRM);
   tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.CommonAndDRM));
-  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.CommonAndDRM));
+  tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.dashjs));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.MULTIPERIOD, engine, new Unstable("ONEM-31620")));
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.Video, new Unstable("ONEM-26268")));
   tests.push(new MvtMediaTest(testChangeAudioTracks, MS.DASH.MULTIAUDIO, engine, null, 40000));
   tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles));
@@ -129,7 +135,8 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
       stream != MS.DASH.WEBM_VP9_OPUS &&
       stream != MS.DASH.DYNAMIC &&
       stream != MS.DASH.FMP4_HEVC_EAC3 &&
-      stream != MS.DASH.CMAF_HEVC_AAC
+      stream != MS.DASH.CMAF_HEVC_AAC &&
+      stream != MS.DASH.MULTIPERIOD
     ); // ONEM-27782
   });
 
@@ -138,18 +145,21 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   tests.push(new MvtMediaTest(testPlayback, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testPlayback, MS.DASH.FMP4_HEVC_EAC3, engine));
   tests.push(new MvtMediaTest(testPlayback, MS.DASH.CMAF_HEVC_AAC, engine, new Unstable("ONEM-29170")));
+  tests.push(new MvtMediaTest(testPlayback, MS.DASH.MULTIPERIOD, engine, new Unstable("ONEM-27782")));
 
   tests = tests.concat(makeMvtMediaTests(testPause, engine, StreamSets.DASH.html5));
   tests.push(new MvtMediaTest(testPause, MS.DASH.WEBM_VP9_OPUS, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testPause, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testPause, MS.DASH.FMP4_HEVC_EAC3, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testPause, MS.DASH.CMAF_HEVC_AAC, engine, new Unstable("ONEM-29170")));
+  tests.push(new MvtMediaTest(testPause, MS.DASH.MULTIPERIOD, engine, new Unstable("ONEM-27782")));
 
   tests = tests.concat(makeMvtMediaTests(testSetPosition, engine, StreamSets.DASH.html5));
   tests.push(new MvtMediaTest(testSetPosition, MS.DASH.WEBM_VP9_OPUS, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testSetPosition, MS.DASH.DYNAMIC, engine, new Unstable("ONEM-27782")));
   tests.push(new MvtMediaTest(testSetPosition, MS.DASH.FMP4_HEVC_EAC3, engine));
   tests.push(new MvtMediaTest(testSetPosition, MS.DASH.CMAF_HEVC_AAC, engine, new Unstable("ONEM-29170")));
+  tests.push(new MvtMediaTest(testSetPosition, MS.DASH.MULTIPERIOD, engine, new Unstable("ONEM-27782")));
 
   // tests = tests.concat(makeMvtMediaTests(testPlayRate, engine, StreamSets.DASH.html5, new Unstable("ONEM-26268")));
   tests = tests.concat(makeMvtMediaTests(testSubtitles, engine, StreamSets.DASH.Subtitles, new Unstable("ONEM-27782")));

--- a/src/suites.js
+++ b/src/suites.js
@@ -107,7 +107,7 @@ window.testSuiteVersions[testVersion]["config"]["defaultTestSuite"] = "codec-sup
   let skipTests = {};
   StreamSets.DASH.dashjs = StreamSets.DASH.CommonAndDRM.filter((stream) => {
     return (
-      stream != MS.MULTIPERIOD // ONEM-31620
+      stream != MS.DASH.MULTIPERIOD // ONEM-31620
     );
   });
 


### PR DESCRIPTION
Following MULTIPERIOD tests recovered as mandatory:
- Dash shaka test suite: Playback, Pause and Seek
- Dash dashjs test suite: Playback and Pause