### PR TITLE
ARRISAPOL-3649: HLS hlsjs tests for Playrate fails

### DIFF
--- a/src/mediaTests.js
+++ b/src/mediaTests.js
@@ -127,7 +127,7 @@ var testPlayback = new TestTemplate("Playback", function (video, runner) {
 });
 
 var testPlayRate = new TestTemplate("PlayRate", function (video, runner) {
-  const rates = [0.5, 2, 0.75, 1.5, 0];
+  const rates = [0.5, 2, 0.75, 1.5];
   const initialPosition = video.currentTime + 1;
   const hasVideoTrack = this.content.video;
 


### PR DESCRIPTION
It is seen that in the MVT Play rate tests, play rate value of 0 is also added along with other rates like 0.5, 0.75, 1.5 and 2. Play rate of 0 corresponds to pausing the playback. On removing the value of 0 from the test, the test cases are passing when tested locally. For pause functionality we have other test cases in MVT. Hence we don't need play rate of 0 in the MVT play rate test cases and hence can it be removed.