### PR TITLE
Remove "download media assets" tab

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -19,4 +19,3 @@
 
 mkdir -p ${TEST_MATERIALS_SRC:-/data/test-materials}
 docker run -v ${TEST_MATERIALS_SRC:-/data/test-materials}:/home/MVT/test-materials --rm -d --name mvt-app -p ${PORT:-80}:80 mvt-app-img
-docker cp download-test-materials.sh mvt-app:/usr/local/apache2/cgi-bin/

--- a/download-test-materials.sh
+++ b/download-test-materials.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-echo -e "Content-Type: application/x-tar"
-echo -e "Content-Disposition: attachment; filename=test-materials.tar.gz"
-echo ""
-tar -czf - -C /home/MVT test-materials
-

--- a/httpd.conf
+++ b/httpd.conf
@@ -72,8 +72,7 @@ LogLevel warn
 
 <Directory "/usr/local/apache2/cgi-bin">
     AllowOverride none
-    Options +ExecCGI
-    AddHandler cgi-script.sh
+    Options None
     Require all granted
 </Directory>
 

--- a/patches/0007_js_mse_eme_mvt_Add_Browse_Media_Assets.patch
+++ b/patches/0007_js_mse_eme_mvt_Add_Browse_Media_Assets.patch
@@ -1,13 +1,12 @@
 diff --git a/harness/compactTestView.js b/harness/compactTestView.js
-index ddf3c9e..70d6b22 100644
+index ddf3c9e..0175e6a 100644
 --- a/harness/compactTestView.js
 +++ b/harness/compactTestView.js
-@@ -56,6 +56,8 @@ var compactTestView = (function() {
+@@ -56,6 +56,7 @@ var compactTestView = (function() {
        this.addLink('CSS Tests', 'https://css3test.com');
        this.addLink('JS ECMAScript Tests','https://compat-table.github.io/compat-table/es2016plus/');
        this.addLink('WPT Tests', 'https://wpt.live/');
 +      this.addLink('Browse Media Assets', 'https://mvt.onemw.net/test-materials/');
-+      this.addLink('Download Media Assets', 'http://mvt.onemw.net/cgi-bin/download-test-materials.sh');
        this.addTestSuites(testSuiteVersions[this.testSuiteVer].testSuites);
  
        for (var engineId in EngineVersions) {

--- a/prepare_submodule.sh
+++ b/prepare_submodule.sh
@@ -27,5 +27,5 @@ git apply ../patches/0003_js_mse_eme_mvt_Add_HtmlTests.patch
 git apply ../patches/0004_js_mse_eme_mvt_Add_CSSTests.patch
 git apply ../patches/0005_js_mse_eme_mvt_Add_JSTests.patch
 git apply ../patches/0006_js_mse_eme_mvt_Add_WPTTests.patch
-git apply ../patches/0007_js_mse_eme_mvt_Add_Browse_and_Download_Media_Assets.patch
+git apply ../patches/0007_js_mse_eme_mvt_Add_Browse_Media_Assets.patch
 


### PR DESCRIPTION
Remove "download media assets" tab (ONEM-25816) since MVT AWS EC2 instance doesn't have enough space to support the download. Also it will fix the docker start issue caused by https://github.com/rdkcentral/MVT/pull/74