### PR TITLE
ARRISAPOL-3759 testSubtitles: do not modify static test data

### DIFF
--- a/src/mediaTests.js
+++ b/src/mediaTests.js
@@ -317,7 +317,7 @@ var testSubtitles = new TestTemplate("Subtitles", function (video, runner) {
   this.content.subtitles.languages.sort();
   let languages = this.content.subtitles.languages.slice();
   if (this.content.subtitles.testLanguages) {
-    languages = this.content.subtitles.testLanguages;
+    languages = this.content.subtitles.testLanguages.slice();
   }
   languages.reverse();
   // Set the first language twice at start and end


### PR DESCRIPTION
When subtitle test is started, one of the member arrays:

- this.content.subtitles.languages, or
- this.content.subtitles.testLanguages

is cloned and extended by 1 new entry.
The 'cloning' part wasn't the case for testLanguages case; it was being used directly - and so when the test using testLanguages was run in loop, testLanguages array was being extended with each test run, making the test take more time, until default timeout (30sec) was being reached. The change corrects the problem.

Verified locally, with docker mvt image.