### PR TITLE
ARRISEOS-49928: Update Html5 test url

### DIFF
--- a/html-tests.html
+++ b/html-tests.html
@@ -10,7 +10,7 @@
     <h1>HTML Tests</h1>
     
     <div class="container">
-        <a href="https://html5test.com" class="nav-button" id="button1" tabindex="0">
+        <a href="https://html5test.opensuse.org/" class="nav-button" id="button1" tabindex="0">
             HTML Test
         </a>
     </div>
@@ -54,7 +54,7 @@
             
             if (e.key === 'Enter') {
                 if (focusedElement.id === 'button1') {
-                    window.location.href = 'https://html5test.com';
+                    window.location.href = 'https://html5test.opensuse.org/';
                 }
             }
         });

--- a/patches/0003_js_mse_eme_mvt_Add_HtmlTests.patch
+++ b/patches/0003_js_mse_eme_mvt_Add_HtmlTests.patch
@@ -6,7 +6,7 @@ index 4dc6fb0..35c6b10 100644
        this.addLink('Content Licenses', 'licenses.html');
        this.addLink('Media Coverage', 'coverage.html');
        this.addLink('Test Any Player', '/anyplayer');
-+      this.addLink('HTML Tests', 'https://html5test.com');
++      this.addLink('HTML Tests', 'https://html5test.opensuse.org/');
        this.addTestSuites(testSuiteVersions[this.testSuiteVer].testSuites);
  
        for (var engineId in EngineVersions) {

--- a/patches/0004_js_mse_eme_mvt_Add_CSSTests.patch
+++ b/patches/0004_js_mse_eme_mvt_Add_CSSTests.patch
@@ -5,7 +5,7 @@ index 35c6b10..52013fb 100644
 @@ -53,6 +53,7 @@ var compactTestView = (function() {
        this.addLink('Media Coverage', 'coverage.html');
        this.addLink('Test Any Player', '/anyplayer');
-       this.addLink('HTML Tests', 'https://html5test.com');
+       this.addLink('HTML Tests', 'https://html5test.opensuse.org/');
 +      this.addLink('CSS Tests', 'https://css3test.com');
        this.addTestSuites(testSuiteVersions[this.testSuiteVer].testSuites);
  

--- a/patches/0005_js_mse_eme_mvt_Add_JSTests.patch
+++ b/patches/0005_js_mse_eme_mvt_Add_JSTests.patch
@@ -4,7 +4,7 @@ index 52013fb..21f062d 100644
 +++ b/harness/compactTestView.js
 @@ -54,6 +54,7 @@ var compactTestView = (function() {
        this.addLink('Test Any Player', '/anyplayer');
-       this.addLink('HTML Tests', 'https://html5test.com');
+       this.addLink('HTML Tests', 'https://html5test.opensuse.org/');
        this.addLink('CSS Tests', 'https://css3test.com');
 +      this.addLink('JS ECMAScript Tests','https://compat-table.github.io/compat-table/es2016plus/');
        this.addTestSuites(testSuiteVersions[this.testSuiteVer].testSuites);

--- a/patches/0006_js_mse_eme_mvt_Add_WPTTests.patch
+++ b/patches/0006_js_mse_eme_mvt_Add_WPTTests.patch
@@ -3,7 +3,7 @@ index 21f062d..ddf3c9e 100644
 --- a/harness/compactTestView.js
 +++ b/harness/compactTestView.js
 @@ -55,6 +55,7 @@ var compactTestView = (function() {
-       this.addLink('HTML Tests', 'https://html5test.com');
+       this.addLink('HTML Tests', 'https://html5test.opensuse.org/');
        this.addLink('CSS Tests', 'https://css3test.com');
        this.addLink('JS ECMAScript Tests','https://compat-table.github.io/compat-table/es2016plus/');
 +      this.addLink('WPT Tests', 'https://wpt.live/');

--- a/patches/0014_js_mse_eme_mvt_Add_Back_to_Main_Page_Button.patch
+++ b/patches/0014_js_mse_eme_mvt_Add_Back_to_Main_Page_Button.patch
@@ -6,7 +6,7 @@ index 6018e18..86f876a 100644
        this.addLink('Content Licenses', 'licenses.html');
        this.addLink('Media Coverage', 'coverage.html');
        this.addLink('Test Any Player', '/anyplayer');
--      this.addLink('HTML Tests', 'https://html5test.com');
+-      this.addLink('HTML Tests', 'https://html5test.opensuse.org/');
 -      this.addLink('CSS Tests', 'https://css3test.com');
 -      this.addLink('JS ECMAScript Tests','https://compat-table.github.io/compat-table/es2016plus/');
 -      this.addLink('WPT Tests', 'https://wpt.live/');


### PR DESCRIPTION
Replacing html5 test url https://html5test.com/ which is now dead with https://html5test.opensuse.org/