### PR TITLE
Add back button to system fonts test

### DIFF
--- a/fonts.html
+++ b/fonts.html
@@ -123,11 +123,17 @@
 			}
 
 			// Automatically call checkFonts when the page loads
-			window.onload = checkFonts;
+			window.onload = function() {
+				checkFonts();
+				document.getElementById('backLink').focus();
+			};
 		</script>
 	</head>
 	<body>
 		<h1>Supported System Fonts</h1>
+		<a href="#" onclick="history.back(); return false;" class="back-link" tabindex="0" id="backLink">
+			← Go Back to Previous Page
+		</a>
 
 		<table>
 			<thead>

--- a/system-fonts.html
+++ b/system-fonts.html
@@ -11,23 +11,15 @@
     
     <div class="container">
         <!-- Button 1 -->
-        <a href="#" class="nav-button" id="button1" tabindex="0">
+        <a href="fonts.html" class="nav-button" id="button1" tabindex="0">
             Fonts Test
         </a>
-
-        <!-- Go Back Link -->
-        <a href="#" onclick="history.back(); return false;" class="back-link" tabindex="0" id="backLink">
-            ← Go Back to Previous Page
-        </a>
     </div>
 
-    <div id="fontsTestContainer" style="display:none; margin-top:20px;">
-        <iframe
-            id="fontsTestFrame"
-            src="fonts.html"
-            width="500%" height="850" style="border:none;">
-        </iframe>
-    </div>
+    <!-- Go Back Link -->
+    <a href="#" onclick="history.back(); return false;" class="back-link" tabindex="0" id="backLink">
+        ← Go Back to Previous Page
+    </a>
 
     <script>
         // Focus on the first button when the page loads
@@ -63,13 +55,9 @@
             
             if (e.key === 'Enter') {
                 if (focusedElement.id === 'button1') {
-                    document.getElementById('fontsTestContainer').style.display = 'block';
+                    window.location.href = 'fonts.html';
                 }
             }
-        });
-        document.getElementById('button1').addEventListener('click', function(e) {
-            e.preventDefault();
-            document.getElementById('fontsTestContainer').style.display = 'block';
         });
     </script>
 


### PR DESCRIPTION
After last MVT deployment, System fonts test was not working after adding it in iframe due to mvt blocking the fonts.html to open in iframe. So added the back button directly on fonts page.